### PR TITLE
Do not apt remove cmake on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.5)
 set(CMAKE_CXX_STANDARD 17)
 
 project(OpenFace VERSION 2.0.2)

--- a/install.sh
+++ b/install.sh
@@ -35,25 +35,7 @@ fi
 
 sudo apt-get -y install build-essential
 sudo apt-get -y install gcc-8 g++-8
-
-# Ubuntu 16.04 does not have newest CMake so need to build it manually
-if [[ `lsb_release -rs` != "18.04" ]]; then   
-  sudo apt-get --purge remove cmake-qt-gui -y
-  sudo apt-get --purge remove cmake -y
-  mkdir -p cmake_tmp
-  cd cmake_tmp
-  wget https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz
-  tar -xzvf cmake-3.10.1.tar.gz
-  cd cmake-3.10.1/
-  ./bootstrap
-  make -j4
-  sudo make install
-  cd ../..
-  sudo rm -r cmake_tmp
-else
-  sudo apt-get -y install cmake
-fi
-
+sudo apt-get -y install cmake
 sudo apt-get -y install zip
 sudo apt-get -y install libopenblas-dev liblapack-dev
 sudo apt-get -y install libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev


### PR DESCRIPTION
Ubuntu 16.04 has cmake 3.5, and it is new enough to build OpenFace.
https://packages.ubuntu.com/ja/xenial/cmake